### PR TITLE
base: add 'make' to base image for all resulting images

### DIFF
--- a/base.dockerfile
+++ b/base.dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
     ca-certificates \
     curl \
+    make \
     python3 \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && update-ca-certificates \
@@ -15,8 +16,7 @@ FROM base AS build
 
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
-    clang \
-    make
+    clang
 
 ENV CC clang
 ENV CXX clang++

--- a/prjtrellis.dockerfile
+++ b/prjtrellis.dockerfile
@@ -29,6 +29,5 @@ COPY --from=build /opt/prjtrellis /
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
     libboost-all-dev \
-    make \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists/*

--- a/symbiyosys.dockerfile
+++ b/symbiyosys.dockerfile
@@ -4,7 +4,6 @@ RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
     binutils \
     g++ \
-    make \
     python3-distutils \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && update-ca-certificates  \

--- a/z3.dockerfile
+++ b/z3.dockerfile
@@ -4,7 +4,6 @@ RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
     binutils \
     g++ \
-    make \
     python3-distutils \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && update-ca-certificates  \


### PR DESCRIPTION
First my apologies, the PR @eine applied here from [ghdl/docker](https://github.com/ghdl/docker) was a bit rashed,
regarding that 'make' commit.

My intention was more what this completes,
to have 'make' in each resulting image.  