### PR TITLE
Update `impl`-image, tests and enable tool version strings

### DIFF
--- a/.github/workflows/impl.yml
+++ b/.github/workflows/impl.yml
@@ -2,6 +2,7 @@
 #   Unai Martinez-Corral
 #
 # Copyright 2019-2021 Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
+# Copyright 2021 Sebastian Birke <git@se-bi.de>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,9 +44,19 @@ jobs:
 
     - run: echo "$(pwd)/.github/bin" >> $GITHUB_PATH
 
-    - run: dockerBuild impl impl
+    - run: dockerBuild impl:ice40      impl ice40
+    - run: dockerBuild impl:icestorm   impl icestorm
+    - run: dockerBuild impl:ecp5       impl ecp5
+    - run: dockerBuild impl:prjtrellis impl prjtrellis
+    - run: dockerBuild impl:pnr        impl pnr
+    - run: dockerBuild impl:latest     impl latest
 
-    - run: dockerTest impl
+    - run: dockerTest  impl:ice40      impl--ice40
+    - run: dockerTest  impl:icestorm   impl--icestorm
+    - run: dockerTest  impl:ecp5       impl--ecp5
+    - run: dockerTest  impl:prjtrellis impl--prjtrellis
+    - run: dockerTest  impl:pnr        impl--pnr
+    - run: dockerTest  impl:latest     impl
 
     - name: Login to DockerHub
       if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
@@ -54,5 +65,20 @@ jobs:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PASS }}
 
-    - run: dockerPush impl
+    - run: dockerPush impl:ice40
+      if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
+
+    - run: dockerPush impl:icestorm
+      if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
+
+    - run: dockerPush impl:ecp5
+      if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
+
+    - run: dockerPush impl:prjtrellis
+      if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
+
+    - run: dockerPush impl:pnr
+      if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
+
+    - run: dockerPush impl:latest
       if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'

--- a/.github/workflows/nextpnr.yml
+++ b/.github/workflows/nextpnr.yml
@@ -45,10 +45,16 @@ jobs:
 
     - run: dockerBuild nextpnr:ice40      nextpnr ice40
     - run: dockerBuild nextpnr:icestorm   nextpnr icestorm
+    - run: dockerBuild pkg:nextpnr-ice40  nextpnr pkg-ice40
     - run: dockerBuild nextpnr:ecp5       nextpnr ecp5
     - run: dockerBuild nextpnr:prjtrellis nextpnr prjtrellis
+    - run: dockerBuild pkg:nextpnr-ecp5   nextpnr pkg-ecp5
+    - run: dockerBuild pkg:nextpnr-all    nextpnr pkg-all
     - run: dockerBuild nextpnr            nextpnr
 
+    - run: dockerTestPkg nextpnr-ice40
+    - run: dockerTestPkg nextpnr-ecp5
+    - run: dockerTestPkg nextpnr-all
     - run: dockerTest nextpnr:ice40
     - run: dockerTest nextpnr:icestorm
     - run: dockerTest nextpnr:ecp5
@@ -68,11 +74,20 @@ jobs:
     - run: dockerPush nextpnr:icestorm
       if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
 
+    - run: dockerPush pkg:nextpnr-ice40
+      if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
+
     - run: dockerPush nextpnr:ecp5
       if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
 
     - run: dockerPush nextpnr:prjtrellis
       if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
 
+    - run: dockerPush pkg:nextpnr-ecp5
+      if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
+
     - run: dockerPush nextpnr
+      if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
+
+    - run: dockerPush pkg:nextpnr-all
       if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'

--- a/base.dockerfile
+++ b/base.dockerfile
@@ -35,6 +35,7 @@ FROM base AS build
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
     clang \
+    git \
     make
 
 ENV CC clang

--- a/nextpnr.dockerfile
+++ b/nextpnr.dockerfile
@@ -73,6 +73,11 @@ COPY --from=hdlc/pkg:icestorm /icestorm /
 
 #---
 
+FROM scratch AS pkg-ice40
+COPY --from=build-ice40 /opt/nextpnr /nextpnr-ice40
+
+#---
+
 FROM build-gitfetch AS build-ecp5
 COPY --from=hdlc/pkg:prjtrellis /prjtrellis /
 
@@ -97,6 +102,11 @@ COPY --from=hdlc/pkg:prjtrellis /prjtrellis /
 
 #---
 
+FROM scratch AS pkg-ecp5
+COPY --from=build-ecp5 /opt/nextpnr /nextpnr-ecp5
+
+#---
+
 FROM build-ice40 AS build-all
 COPY --from=hdlc/pkg:prjtrellis /prjtrellis /
 
@@ -108,6 +118,11 @@ RUN cd /tmp/nextpnr/build \
    -DUSE_OPENMP=ON \
  && make -j $(nproc) \
  && make DESTDIR=/opt/nextpnr install
+
+#---
+
+FROM scratch AS pkg-all
+COPY --from=build-all /opt/nextpnr /nextpnr-all
 
 #---
 

--- a/nextpnr.dockerfile
+++ b/nextpnr.dockerfile
@@ -43,10 +43,9 @@ RUN apt-get update -qq \
 FROM build AS build-ice40
 COPY --from=hdlc/pkg:icestorm /icestorm/usr/local/share/icebox /usr/local/share/icebox
 
-RUN mkdir -p /tmp/nextpnr/build \
- && cd /tmp/nextpnr \
- && curl -fsSL https://codeload.github.com/YosysHQ/nextpnr/tar.gz/master | tar xzf - --strip-components=1 \
- && cd build \
+RUN git clone https://github.com/YosysHQ/nextpnr.git /tmp/nextpnr \
+ && mkdir /tmp/nextpnr/build/ \
+ && cd /tmp/nextpnr/build \
  && cmake .. \
    -DARCH=ice40 \
    -DBUILD_GUI=OFF \
@@ -70,10 +69,9 @@ COPY --from=hdlc/pkg:icestorm /icestorm /
 FROM build AS build-ecp5
 COPY --from=hdlc/pkg:prjtrellis /prjtrellis /
 
-RUN mkdir -p /tmp/nextpnr/build \
- && cd /tmp/nextpnr \
- && curl -fsSL https://codeload.github.com/YosysHQ/nextpnr/tar.gz/master | tar xzf - --strip-components=1 \
- && cd build \
+RUN git clone https://github.com/YosysHQ/nextpnr.git /tmp/nextpnr \
+ && mkdir /tmp/nextpnr/build/ \
+ && cd /tmp/nextpnr/build \
  && cmake .. \
    -DARCH=ecp5 \
    -DBUILD_GUI=OFF \

--- a/test/impl--ecp5.sh
+++ b/test/impl--ecp5.sh
@@ -25,17 +25,6 @@ set -e
 
 cd $(dirname "$0")
 
-./_env.sh
-
-./smoke-tests/ghdl.sh
-./smoke-tests/nextpnr.sh
-./smoke-tests/yosys.sh
-
 ./ghdl.sh
 ./yosys.sh
-
-./nextpnr--ice40.sh
-./icestorm.sh
-
 ./nextpnr--ecp5.sh
-./prjtrellis.sh

--- a/test/impl--ice40.sh
+++ b/test/impl--ice40.sh
@@ -25,17 +25,6 @@ set -e
 
 cd $(dirname "$0")
 
-./_env.sh
-
-./smoke-tests/ghdl.sh
-./smoke-tests/nextpnr.sh
-./smoke-tests/yosys.sh
-
 ./ghdl.sh
 ./yosys.sh
-
 ./nextpnr--ice40.sh
-./icestorm.sh
-
-./nextpnr--ecp5.sh
-./prjtrellis.sh

--- a/test/impl--icestorm.sh
+++ b/test/impl--icestorm.sh
@@ -25,17 +25,8 @@ set -e
 
 cd $(dirname "$0")
 
-./_env.sh
-
-./smoke-tests/ghdl.sh
-./smoke-tests/nextpnr.sh
-./smoke-tests/yosys.sh
-
 ./ghdl.sh
 ./yosys.sh
 
 ./nextpnr--ice40.sh
 ./icestorm.sh
-
-./nextpnr--ecp5.sh
-./prjtrellis.sh

--- a/test/impl--pnr.sh
+++ b/test/impl--pnr.sh
@@ -25,17 +25,8 @@ set -e
 
 cd $(dirname "$0")
 
-./_env.sh
-
-./smoke-tests/ghdl.sh
-./smoke-tests/nextpnr.sh
-./smoke-tests/yosys.sh
-
 ./ghdl.sh
 ./yosys.sh
 
-./nextpnr--ice40.sh
-./icestorm.sh
-
 ./nextpnr--ecp5.sh
-./prjtrellis.sh
+./nextpnr--ice40.sh

--- a/test/impl--prjtrellis.sh
+++ b/test/impl--prjtrellis.sh
@@ -25,17 +25,8 @@ set -e
 
 cd $(dirname "$0")
 
-./_env.sh
-
-./smoke-tests/ghdl.sh
-./smoke-tests/nextpnr.sh
-./smoke-tests/yosys.sh
-
 ./ghdl.sh
 ./yosys.sh
-
-./nextpnr--ice40.sh
-./icestorm.sh
 
 ./nextpnr--ecp5.sh
 ./prjtrellis.sh

--- a/test/nextpnr--ecp5.sh
+++ b/test/nextpnr--ecp5.sh
@@ -27,4 +27,6 @@ cd $(dirname "$0")
 
 ./smoke-tests/nextpnr-ecp5.sh
 
+nextpnr-ecp5 --version
+
 ./_todo.sh

--- a/test/nextpnr--ice40.sh
+++ b/test/nextpnr--ice40.sh
@@ -27,4 +27,6 @@ cd $(dirname "$0")
 
 ./smoke-tests/nextpnr-ice40.sh
 
+nextpnr-ice40 --version
+
 ./_todo.sh

--- a/test/nextpnr-all.pkg.sh
+++ b/test/nextpnr-all.pkg.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# Authors:
+#   Sebastian Birke
+#
+# Copyright 2020-2021 Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
+# Copyright 2020-2021 Sebastian Birke <git@se-bi.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cd $(dirname "$0")
+
+./_tree.sh
+
+./_todo.sh

--- a/test/nextpnr-ecp5.pkg.sh
+++ b/test/nextpnr-ecp5.pkg.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# Authors:
+#   Sebastian Birke
+#
+# Copyright 2020-2021 Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
+# Copyright 2020-2021 Sebastian Birke <git@se-bi.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cd $(dirname "$0")
+
+./_tree.sh
+
+file /usr/local/bin/nextpnr-ecp5
+
+./_todo.sh

--- a/test/nextpnr-ice40.pkg.sh
+++ b/test/nextpnr-ice40.pkg.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# Authors:
+#   Sebastian Birke
+#
+# Copyright 2020-2021 Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
+# Copyright 2020-2021 Sebastian Birke <git@se-bi.de>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cd $(dirname "$0")
+
+./_tree.sh
+
+file /usr/local/bin/nextpnr-ice40
+
+./_todo.sh

--- a/test/nextpnr.sh
+++ b/test/nextpnr.sh
@@ -27,4 +27,7 @@ cd $(dirname "$0")
 
 ./smoke-tests/nextpnr.sh
 
+nextpnr-ecp5 --version
+nextpnr-ice40 --version
+
 ./_todo.sh

--- a/test/prjtrellis.sh
+++ b/test/prjtrellis.sh
@@ -27,4 +27,6 @@ cd $(dirname "$0")
 
 ./smoke-tests/prjtrellis.sh
 
+ecppack --version
+
 ./_todo.sh

--- a/yosys.dockerfile
+++ b/yosys.dockerfile
@@ -39,15 +39,14 @@ RUN apt-get update -qq \
     flex \
     gawk \
     gcc \
-    git \
     iverilog \
     pkg-config \
     zlib1g-dev \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir /tmp/yosys && cd /tmp/yosys \
- && curl -fsSL https://codeload.github.com/YosysHQ/yosys/tar.gz/master | tar xzf - --strip-components=1 \
+RUN git clone https://github.com/YosysHQ/yosys.git /tmp/yosys \
+ && cd /tmp/yosys \
  && make -j $(nproc) \
  && make DESTDIR=/opt/yosys install \
  && make test


### PR DESCRIPTION
Thanks, @eine for the discussion on #1 and adding the _impl_ image.  
(Surprisingly, the documentation was ahead ... :relieved: )

Some ideas came up on that:
- Separating impl images regarding ice40 and ecp5 architectures
- Adding tools of icestorm and prjtrellis, respectively
- Clone Github Projects instead of Tar-archive via codeload, to have a meaningful `--version` return of the builds
- Add some test calls of tools (`--version` or similar)

(see the [CI runs](https://github.com/se-bi/hdl-containers/actions?query=+branch%3Atest%2Fbuild-version++), which are not running unchanged parts and pushing into different DockerHub Repositories
https://github.com/se-bi/hdl-containers/compare/develop...se-bi:test/build-version)