### PR TITLE
Feature/tool version string

### DIFF
--- a/base.dockerfile
+++ b/base.dockerfile
@@ -35,6 +35,7 @@ FROM base AS build
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
     clang \
+    git \
     make
 
 ENV CC clang

--- a/nextpnr.dockerfile
+++ b/nextpnr.dockerfile
@@ -43,10 +43,9 @@ RUN apt-get update -qq \
 FROM build AS build-ice40
 COPY --from=hdlc/pkg:icestorm /icestorm/usr/local/share/icebox /usr/local/share/icebox
 
-RUN mkdir -p /tmp/nextpnr/build \
- && cd /tmp/nextpnr \
- && curl -fsSL https://codeload.github.com/YosysHQ/nextpnr/tar.gz/master | tar xzf - --strip-components=1 \
- && cd build \
+RUN git clone https://github.com/YosysHQ/nextpnr.git /tmp/nextpnr \
+ && mkdir /tmp/nextpnr/build/ \
+ && cd /tmp/nextpnr/build \
  && cmake .. \
    -DARCH=ice40 \
    -DBUILD_GUI=OFF \
@@ -70,10 +69,9 @@ COPY --from=hdlc/pkg:icestorm /icestorm /
 FROM build AS build-ecp5
 COPY --from=hdlc/pkg:prjtrellis /prjtrellis /
 
-RUN mkdir -p /tmp/nextpnr/build \
- && cd /tmp/nextpnr \
- && curl -fsSL https://codeload.github.com/YosysHQ/nextpnr/tar.gz/master | tar xzf - --strip-components=1 \
- && cd build \
+RUN git clone https://github.com/YosysHQ/nextpnr.git /tmp/nextpnr \
+ && mkdir /tmp/nextpnr/build/ \
+ && cd /tmp/nextpnr/build \
  && cmake .. \
    -DARCH=ecp5 \
    -DBUILD_GUI=OFF \

--- a/test/nextpnr--ecp5.sh
+++ b/test/nextpnr--ecp5.sh
@@ -27,4 +27,6 @@ cd $(dirname "$0")
 
 ./smoke-tests/nextpnr-ecp5.sh
 
+nextpnr-ecp5 --version
+
 ./_todo.sh

--- a/test/nextpnr--ice40.sh
+++ b/test/nextpnr--ice40.sh
@@ -27,4 +27,6 @@ cd $(dirname "$0")
 
 ./smoke-tests/nextpnr-ice40.sh
 
+nextpnr-ice40 --version
+
 ./_todo.sh

--- a/test/nextpnr.sh
+++ b/test/nextpnr.sh
@@ -27,4 +27,7 @@ cd $(dirname "$0")
 
 ./smoke-tests/nextpnr.sh
 
+nextpnr-ecp5 --version
+nextpnr-ice40 --version
+
 ./_todo.sh

--- a/test/prjtrellis.sh
+++ b/test/prjtrellis.sh
@@ -27,4 +27,6 @@ cd $(dirname "$0")
 
 ./smoke-tests/prjtrellis.sh
 
+ecppack --version
+
 ./_todo.sh

--- a/yosys.dockerfile
+++ b/yosys.dockerfile
@@ -39,15 +39,14 @@ RUN apt-get update -qq \
     flex \
     gawk \
     gcc \
-    git \
     iverilog \
     pkg-config \
     zlib1g-dev \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir /tmp/yosys && cd /tmp/yosys \
- && curl -fsSL https://codeload.github.com/YosysHQ/yosys/tar.gz/master | tar xzf - --strip-components=1 \
+RUN git clone https://github.com/YosysHQ/yosys.git /tmp/yosys \
+ && cd /tmp/yosys \
  && make -j $(nproc) \
  && make DESTDIR=/opt/yosys install \
  && make test


### PR DESCRIPTION
Hey,
as discussed in #4, the first part:
adding git to a base building images and get source code later by git clone to derive version strings.

Spoiler alert, due to missing workflow dependencies and change in the base images which is already used for the other changes, those two other builds (nextpnr, yosys) fail on the first run :see_no_evil: 