### PR TITLE
impl: restructure, add different images with prj tools

### DIFF
--- a/.github/workflows/impl.yml
+++ b/.github/workflows/impl.yml
@@ -1,5 +1,6 @@
 # Authors:
 #   Unai Martinez-Corral
+#   Sebastian Birke      <git@se-bi.de>
 #
 # Copyright 2019-2021 Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
 #
@@ -43,9 +44,21 @@ jobs:
 
     - run: echo "$(pwd)/.github/bin" >> $GITHUB_PATH
 
-    - run: dockerBuild impl impl
+    - run: dockerBuild impl:ecp5       impl ecp5
+    - run: dockerBuild impl:ice40      impl ice40
+    - run: dockerBuild impl:generic    impl generic
+    - run: dockerBuild impl:icestorm   impl icestorm
+    - run: dockerBuild impl:prjtrellis impl prjtrellis
+    - run: dockerBuild impl:pnr        impl pnr
+    - run: dockerBuild impl            impl
 
-    - run: dockerTest impl
+    - run: dockerTest  impl:ecp5       impl--ecp5
+    - run: dockerTest  impl:ice40      impl--ice40
+    - run: dockerTest  impl:generic    impl--generic
+    - run: dockerTest  impl:icestorm   impl--icestorm
+    - run: dockerTest  impl:prjtrellis impl--prjtrellis
+    - run: dockerTest  impl:pnr        impl--pnr
+    - run: dockerTest  impl            impl
 
     - name: Login to DockerHub
       if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
@@ -57,4 +70,10 @@ jobs:
     - if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
       run: >-
         dockerPush
+        impl:ecp5
+        impl:ice40
+        impl:generic
+        impl:icestorm
+        impl:prjtrellis
+        impl:pnr
         impl

--- a/doc/index.adoc
+++ b/doc/index.adoc
@@ -24,7 +24,14 @@ include::tools.adoc[]
 
 Images including multiple tools:
 
-* **I**mplementation: https://hub.docker.com/r/hdlc/impl/tags[image:https://img.shields.io/docker/image-size/hdlc/impl?longCache=true&style=flat-square&label=hdlc%2Fimpl&logo=Docker&logoColor=fff[title='hdlc/impl:latest Docker image size']]
+* **I**mplementation:
+** https://hub.docker.com/r/hdlc/impl/tags[image:https://img.shields.io/docker/image-size/hdlc/impl/ecp5?longCache=true&style=flat-square&label=hdlc%2Fimpl:ecp5&logo=Docker&logoColor=fff[title='hdlc/impl:ecp5 Docker image size']] GHDL + Yosys + nextpnr-ecp5
+** https://hub.docker.com/r/hdlc/impl/tags[image:https://img.shields.io/docker/image-size/hdlc/impl/ice40?longCache=true&style=flat-square&label=hdlc%2Fimpl:ice40&logo=Docker&logoColor=fff[title='hdlc/impl:ice40 Docker image size']] GHDL + Yosys + nextpnr-ice40
+** https://hub.docker.com/r/hdlc/impl/tags[image:https://img.shields.io/docker/image-size/hdlc/impl/generic?longCache=true&style=flat-square&label=hdlc%2Fimpl:generic&logo=Docker&logoColor=fff[title='hdlc/impl:generic Docker image size']] GHDL + Yosys + nextpnr-generic
+** https://hub.docker.com/r/hdlc/impl/tags[image:https://img.shields.io/docker/image-size/hdlc/impl/icestorm?longCache=true&style=flat-square&label=hdlc%2Fimpl:icestorm&logo=Docker&logoColor=fff[title='hdlc/impl:icestorm Docker image size']] impl:ice40 + icestorm
+** https://hub.docker.com/r/hdlc/impl/tags[image:https://img.shields.io/docker/image-size/hdlc/impl/prjtrellis?longCache=true&style=flat-square&label=hdlc%2Fimpl:prjtrellis&logo=Docker&logoColor=fff[title='hdlc/impl:prjtrellis Docker image size']] impl:ecp5 + prjtrellis
+** https://hub.docker.com/r/hdlc/impl/tags[image:https://img.shields.io/docker/image-size/hdlc/impl/pnr?longCache=true&style=flat-square&label=hdlc%2Fimpl:pnr&logo=Docker&logoColor=fff[title='hdlc/impl:pnr Docker image size']] GHDL + Yosys + nextpnr-ecp5 + nextpnr-ice40 + nextpnr-generic
+** https://hub.docker.com/r/hdlc/impl/tags[image:https://img.shields.io/docker/image-size/hdlc/impl/latest?longCache=true&style=flat-square&label=hdlc%2Fimpl&logo=Docker&logoColor=fff[title='hdlc/impl:latest Docker image size']] impl:pnr + icestorm + prjtrellis
 * **F**ormal:
 ** https://hub.docker.com/r/hdlc/formal/tags[image:https://img.shields.io/docker/image-size/hdlc/formal/latest?longCache=true&style=flat-square&label=hdlc%2Fformal&logo=Docker&logoColor=fff[title='hdlc/formal:latest Docker image size']] all solvers depending on Python 3.
 ** https://hub.docker.com/r/hdlc/formal/tags[image:https://img.shields.io/docker/image-size/hdlc/formal/min?longCache=true&style=flat-square&label=hdlc%2Fformal:min&logo=Docker&logoColor=fff[title='hdlc/formal:min Docker image size']] Z3 only.

--- a/doc/tools.yml
+++ b/doc/tools.yml
@@ -93,6 +93,7 @@ icestorm:
   use:
     - 'icestorm'
   in:
+    - 'impl:icestorm'
     - 'impl'
     - 'prog'
   otherin:
@@ -132,6 +133,7 @@ prjtrellis:
   use:
     - 'prjtrellis'
   in:
+    - 'impl:prjtrellis'
     - 'impl'
   otherin:
     - 'nextpnr:prjtrellis'

--- a/test/impl--ecp5.sh
+++ b/test/impl--ecp5.sh
@@ -24,15 +24,6 @@ set -e
 
 cd $(dirname "$0")
 
-./_env.sh
-
 ./ghdl.sh
 ./yosys.sh
-
 ./nextpnr--ecp5.sh
-./prjtrellis.sh
-
-./nextpnr--ice40.sh
-./icestorm.sh
-
-./nextpnr--generic.sh

--- a/test/impl--generic.sh
+++ b/test/impl--generic.sh
@@ -24,15 +24,6 @@ set -e
 
 cd $(dirname "$0")
 
-./_env.sh
-
 ./ghdl.sh
 ./yosys.sh
-
-./nextpnr--ecp5.sh
-./prjtrellis.sh
-
-./nextpnr--ice40.sh
-./icestorm.sh
-
 ./nextpnr--generic.sh

--- a/test/impl--ice40.sh
+++ b/test/impl--ice40.sh
@@ -24,15 +24,6 @@ set -e
 
 cd $(dirname "$0")
 
-./_env.sh
-
 ./ghdl.sh
 ./yosys.sh
-
-./nextpnr--ecp5.sh
-./prjtrellis.sh
-
 ./nextpnr--ice40.sh
-./icestorm.sh
-
-./nextpnr--generic.sh

--- a/test/impl--icestorm.sh
+++ b/test/impl--icestorm.sh
@@ -24,15 +24,8 @@ set -e
 
 cd $(dirname "$0")
 
-./_env.sh
-
 ./ghdl.sh
 ./yosys.sh
 
-./nextpnr--ecp5.sh
-./prjtrellis.sh
-
 ./nextpnr--ice40.sh
 ./icestorm.sh
-
-./nextpnr--generic.sh

--- a/test/impl--pnr.sh
+++ b/test/impl--pnr.sh
@@ -24,15 +24,9 @@ set -e
 
 cd $(dirname "$0")
 
-./_env.sh
-
 ./ghdl.sh
 ./yosys.sh
 
 ./nextpnr--ecp5.sh
-./prjtrellis.sh
-
 ./nextpnr--ice40.sh
-./icestorm.sh
-
 ./nextpnr--generic.sh

--- a/test/impl--prjtrellis.sh
+++ b/test/impl--prjtrellis.sh
@@ -24,15 +24,8 @@ set -e
 
 cd $(dirname "$0")
 
-./_env.sh
-
 ./ghdl.sh
 ./yosys.sh
 
 ./nextpnr--ecp5.sh
 ./prjtrellis.sh
-
-./nextpnr--ice40.sh
-./icestorm.sh
-
-./nextpnr--generic.sh


### PR DESCRIPTION
Final follow up on #4, as suggested there:

Architecture dependent:
- `impl:ecp5`: GHDL + Yosys + nextpnr-ecp5
- `impl:ice40`: GHDL + Yosys + nextpnr-ice40
- `impl:generic`: GHDL + Yosys + nextpnr-generic
- `impl:pnr`: GHDL + Yosys + nextpnr-ecp5 + nextpnr-ice40 + nextpnr-generic
- `impl:icestorm`: impl:ice40 + icestorm
- `impl:prjtrellis`: impl:ecp5 + prjtrellis
- `impl:latest`: impl:pnr + icestorm + prjtrellis

I updated also the docs,
though i added only some tags which are "unique" for others (`tools.yml`).
Do you want to add all 7 tags at others `in`-sections, it's anyway resulting in the `I` in that column?