### PR TITLE
Verilog-to-Routing

### DIFF
--- a/.github/workflows/vtr.yml
+++ b/.github/workflows/vtr.yml
@@ -1,0 +1,80 @@
+# Authors:
+#   Unai Martinez-Corral
+#
+# Copyright 2019-2021 Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'vtr'
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 0 * * 5'
+  workflow_dispatch:
+  repository_dispatch:
+    types: [ vtr ]
+
+env:
+  DOCKER_BUILDKIT: 1
+
+jobs:
+
+  vtr:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+
+          # Debian Buster
+          - { os: debian/buster, arch: amd64 }
+
+          # Debian Bullseye
+          - { os: debian/bullseye, arch: amd64 }
+
+    env:
+      HDL_ARCH: ${{ matrix.arch }}
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - run: ./utils/setup.sh
+
+    - run: >-
+        dockerBuild -c ${{ matrix.os }} -d
+        pkg/vtr
+        vtr
+
+    - run: dockerTestPkg ${{ matrix.os }} vtr
+    - run: dockerTest ${{ matrix.os }} vtr
+
+    - name: Login to container registries
+      if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
+      uses: ./utils/registry-login
+      with:
+        cmd: |
+          echo '${{ secrets.GCR_JSON_KEY }}' | docker login gcr.io -u _json_key --password-stdin
+          echo '${{ github.token }}' | docker login ghcr.io -u gha --password-stdin
+          echo '${{ secrets.DOCKER_PASS }}' | docker login docker.io -u '${{ secrets.DOCKER_USER }}' --password-stdin
+
+    - if: github.event_name != 'pull_request' && github.repository == 'hdl/containers'
+      run: >-
+        dockerPush ${{ matrix.os }}
+        pkg/vtr
+        vtr

--- a/debian-bullseye/vtr.dockerfile
+++ b/debian-bullseye/vtr.dockerfile
@@ -25,27 +25,19 @@ FROM $REGISTRY/build/dev as build
 
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
-    ninja-build \
-    libssl-dev \
-    autoconf \
-    automake \
     bison \
-    binutils \
-    binutils-gold \
     build-essential \
+    cmake \
     flex \
     fontconfig \
     gperf \
     libcairo2-dev \
     libgtk-3-dev \
-    libevent-dev \
     libfontconfig1-dev \
     liblist-moreutils-perl \
-    libncurses5-dev \
     libx11-dev \
     libxft-dev \
-    libxml++2.6-dev \
-    python3-lxml \
+    ninja-build \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists/*
 

--- a/debian-bullseye/vtr.dockerfile
+++ b/debian-bullseye/vtr.dockerfile
@@ -42,15 +42,11 @@ RUN apt-get update -qq \
  && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/verilog-to-routing/vtr-verilog-to-routing.git /tmp/vtr \
- && cd /tmp/vtr \
- && make PREFIX=/usr/local -j $(nproc) \
- && make DESTDIR=/opt/vtr PREFIX=/usr/local install
-
-# FIXME: This should not be required, but the PREFIX in the previous step seems not to be honored.
-RUN cd /opt/vtr \
- && mkdir usr \
- && mv tmp/vtr/build usr/local \
- && rm -rf tmp
+ && mkdir -p /tmp/vtr/build \
+ && cd /tmp/vtr/build \
+ && cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX="/usr/local" .. \
+ && cmake --build ./ \
+ && DESTDIR=/opt/vtr cmake --build ./ --target install
 
 #---
 

--- a/debian-bullseye/vtr.dockerfile
+++ b/debian-bullseye/vtr.dockerfile
@@ -1,0 +1,81 @@
+# Authors:
+#   Unai Martinez-Corral
+#
+# Copyright 2021 Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ARG REGISTRY='gcr.io/hdl-containers/debian/bullseye'
+
+#---
+
+FROM $REGISTRY/build/dev as build
+
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    ninja-build \
+    libssl-dev \
+    autoconf \
+    automake \
+    bison \
+    binutils \
+    binutils-gold \
+    build-essential \
+    flex \
+    fontconfig \
+    gperf \
+    libcairo2-dev \
+    libgtk-3-dev \
+    libevent-dev \
+    libfontconfig1-dev \
+    liblist-moreutils-perl \
+    libncurses5-dev \
+    libx11-dev \
+    libxft-dev \
+    libxml++2.6-dev \
+    python3-lxml \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/verilog-to-routing/vtr-verilog-to-routing.git /tmp/vtr \
+ && cd /tmp/vtr \
+ && make PREFIX=/usr/local -j $(nproc) \
+ && make DESTDIR=/opt/vtr PREFIX=/usr/local install
+
+# FIXME: This should not be required, but the PREFIX in the previous step seems not to be honored.
+RUN cd /opt/vtr \
+ && mkdir usr \
+ && mv tmp/vtr/build usr/local \
+ && rm -rf tmp
+
+#---
+
+FROM scratch AS pkg
+
+COPY --from=build /opt/vtr /vtr
+
+#---
+
+FROM $REGISTRY/build/base
+
+COPY --from=build /opt/vtr /
+
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    libgtk-3-bin \
+ && apt-get autoclean -y && apt-get clean -y && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+CMD ["vpr"]

--- a/debian-buster/vtr.dockerfile
+++ b/debian-buster/vtr.dockerfile
@@ -42,15 +42,11 @@ RUN apt-get update -qq \
  && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/verilog-to-routing/vtr-verilog-to-routing.git /tmp/vtr \
- && cd /tmp/vtr \
- && make PREFIX=/usr/local -j $(nproc) \
- && make DESTDIR=/opt/vtr PREFIX=/usr/local install
-
-# FIXME: This should not be required, but the PREFIX in the previous step seems not to be honored.
-RUN cd /opt/vtr \
- && mkdir usr \
- && mv tmp/vtr/build usr/local \
- && rm -rf tmp
+ && mkdir -p /tmp/vtr/build \
+ && cd /tmp/vtr/build \
+ && cmake -G "Ninja" -DCMAKE_INSTALL_PREFIX="/usr/local" .. \
+ && cmake --build ./ \
+ && DESTDIR=/opt/vtr cmake --build ./ --target install
 
 #---
 

--- a/debian-buster/vtr.dockerfile
+++ b/debian-buster/vtr.dockerfile
@@ -25,27 +25,19 @@ FROM $REGISTRY/build/dev as build
 
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
-    ninja-build \
-    libssl-dev \
-    autoconf \
-    automake \
     bison \
-    binutils \
-    binutils-gold \
     build-essential \
+    cmake \
     flex \
     fontconfig \
     gperf \
     libcairo2-dev \
     libgtk-3-dev \
-    libevent-dev \
     libfontconfig1-dev \
     liblist-moreutils-perl \
-    libncurses5-dev \
     libx11-dev \
     libxft-dev \
-    libxml++2.6-dev \
-    python-lxml \
+    ninja-build \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists/*
 

--- a/debian-buster/vtr.dockerfile
+++ b/debian-buster/vtr.dockerfile
@@ -1,0 +1,81 @@
+# Authors:
+#   Unai Martinez-Corral
+#
+# Copyright 2021 Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ARG REGISTRY='gcr.io/hdl-containers/debian/buster'
+
+#---
+
+FROM $REGISTRY/build/dev as build
+
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    ninja-build \
+    libssl-dev \
+    autoconf \
+    automake \
+    bison \
+    binutils \
+    binutils-gold \
+    build-essential \
+    flex \
+    fontconfig \
+    gperf \
+    libcairo2-dev \
+    libgtk-3-dev \
+    libevent-dev \
+    libfontconfig1-dev \
+    liblist-moreutils-perl \
+    libncurses5-dev \
+    libx11-dev \
+    libxft-dev \
+    libxml++2.6-dev \
+    python-lxml \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/verilog-to-routing/vtr-verilog-to-routing.git /tmp/vtr \
+ && cd /tmp/vtr \
+ && make PREFIX=/usr/local -j $(nproc) \
+ && make DESTDIR=/opt/vtr PREFIX=/usr/local install
+
+# FIXME: This should not be required, but the PREFIX in the previous step seems not to be honored.
+RUN cd /opt/vtr \
+ && mkdir usr \
+ && mv tmp/vtr/build usr/local \
+ && rm -rf tmp
+
+#---
+
+FROM scratch AS pkg
+
+COPY --from=build /opt/vtr /vtr
+
+#---
+
+FROM $REGISTRY/build/base
+
+COPY --from=build /opt/vtr /
+
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    libgtk-3-bin \
+ && apt-get autoclean -y && apt-get clean -y && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+CMD ["vpr"]

--- a/doc/dev/content.adoc
+++ b/doc/dev/content.adoc
@@ -133,6 +133,11 @@ GHAStatus:magic[]
 --
 GHAStatus:netgen[]
 --
+* {blank}
++
+--
+GHAStatus:vtr[]
+--
 
 a|* {blank}
 +

--- a/doc/main/content.adoc
+++ b/doc/main/content.adoc
@@ -92,7 +92,6 @@ include::tools.adoc[]
 * https://hdl.github.io/awesome/items/prjxray[Project X-Ray (Xilinx 7 Series tooling)]
 * https://github.com/SymbiFlow/prjuray[Project U-Ray (Xilinx Ultrascale Series tooling)]
 * https://github.com/SymbiFlow/symbiflow-arch-defs[SymbiFlow Architecture Definitions + Tooling (Xilinx 7 Series, QuickLogic)]
-* https://hdl.github.io/awesome/items/vtr[Verilog To Routing]
 * https://github.com/StefanSchippers/xschem[xschem] (https://github.com/hdl/containers/issues/28[#28])
 * http://opencircuitdesign.com/irsim/[IRSIM] (https://github.com/hdl/containers/issues/30[#30])
 * https://github.com/adamgreig/ecpdap[ecpdap]

--- a/doc/main/tools.yml
+++ b/doc/main/tools.yml
@@ -279,6 +279,16 @@ verilator:
 
 #---
 
+vtr:
+  src: true
+  url: 'https://hdl.github.io/awesome/items/vtr'
+  pkg:
+    - 'vtr'
+  use:
+    - 'vtr'
+
+#---
+
 vunit:
   src: true
   url: 'https://hdl.github.io/awesome/items/vunit'

--- a/graph/graph.dot
+++ b/graph/graph.dot
@@ -56,6 +56,7 @@ digraph G {
       "openfpgaloader"
       "prjtrellis"
       "verilator"
+      "vtr"
       "yosys"
     }
     { node [color=mediumblue, fontcolor=mediumblue]
@@ -83,6 +84,7 @@ digraph G {
       "pkg/yices2"
       "pkg/yosys"
       "pkg/verilator"
+      "pkg/vtr"
       "pkg/z3"
     }
     { node [color=brown, fontcolor=brown]
@@ -216,6 +218,8 @@ digraph G {
       "pkg/openfpgaloader"
       "prjtrellis"
       "pkg/prjtrellis"
+      "vtr"
+      "pkg/vtr"
     }
   }
 

--- a/graph/impl.dot
+++ b/graph/impl.dot
@@ -33,6 +33,7 @@ digraph G {
     d_openfpgaloader [label="openfpgaloader"];
     d_prjtrellis     [label="prjtrellis"];
     d_prog           [label="prog"];
+    d_vtr            [label="vtr"];
   }
 
   # Images
@@ -52,6 +53,7 @@ digraph G {
       "nextpnr"
       "openfpgaloader"
       "prjtrellis"
+      "vtr"
     }
     { node [color=mediumblue, fontcolor=mediumblue]
       "pkg/apicula"
@@ -62,6 +64,7 @@ digraph G {
       "pkg/nextpnr/ecp5"
       "pkg/openfpgaloader"
       "pkg/prjtrellis"
+      "pkg/vtr"
     }
     { node [color=brown, fontcolor=brown]
       "nextpnr/icestorm"
@@ -331,6 +334,29 @@ digraph G {
     "prog" -> "t_prog";
   }
 
+  subgraph cluster_vtr {
+    { rank=same
+      node [shape=cylinder, color=grey, fontcolor=grey]
+      "p_vtr_build/dev"    [label="build/dev"]
+      "p_vtr_build/base"   [label="build/base"]
+      "p_vtr_scratch"      [label="scratch"]
+    }
+
+    d_vtr -> {
+      "vtr"
+      "pkg/vtr"
+     } [style=dotted];
+
+    { rank=same
+      node [shape=folder, color=red, fontcolor=red]
+      "t_vtr"     [label="vtr"];
+      "t_pkg/vtr" [label="vtr.pkg"];
+    }
+
+    "vtr" -> "t_vtr";
+    "pkg/vtr" -> "t_pkg/vtr";
+  }
+
   { rank=same
     d_icestorm
     d_prjtrellis
@@ -381,6 +407,10 @@ digraph G {
   "build/base" -> "p_prog_build/base" -> d_prog;
   "pkg/icestorm" -> "p_prog_icestorm" -> d_prog;
 
+  "build/dev" -> "p_vtr_build/dev" -> d_vtr;
+  "build/base" -> "p_vtr_build/base" -> d_vtr;
+  "scratch" -> "p_vtr_scratch" -> d_vtr;
+
   # Image dependencies
 
   { edge [style=dashed]
@@ -427,6 +457,9 @@ digraph G {
 
     "p_prjtrellis_scratch" -> "pkg/prjtrellis";
     "p_prjtrellis_build/base" -> "prjtrellis";
+
+    "p_vtr_build/base" -> "vtr";
+    "p_vtr_scratch" -> "pkg/vtr";
   }
 
   { edge [style=dashed, color=grey]

--- a/test/vtr.pkg.sh
+++ b/test/vtr.pkg.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# Authors:
+#   Unai Martinez-Corral
+#
+# Copyright 2020-2021 Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cd $(dirname "$0")
+
+./_tree.sh
+
+./_todo.sh

--- a/test/vtr.sh
+++ b/test/vtr.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+
+# Authors:
+#   Unai Martinez-Corral
+#
+# Copyright 2020-2021 Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cd $(dirname "$0")
+
+./_env.sh
+
+./smoke-tests/vpr.sh
+./smoke-tests/odin_II.sh
+
+./_todo.sh

--- a/utils/pyHDLC/build.py
+++ b/utils/pyHDLC/build.py
@@ -85,6 +85,8 @@ DefaultOpts: Dict[str, Tuple[str, str, str]] = {
     "pkg/symbiyosys": ["symbiyosys", None, None],
     "verilator": ["verilator", None, None],
     "pkg/verilator": ["verilator", "pkg", None],
+    "vtr": ["vtr", None, None],
+    "pkg/vtr": ["vtr", "pkg", None],
     "xyce": ["xyce", None, None],
     "pkg/xyce": ["xyce", "pkg", None],
     "pkg/yices2": ["yices2", None, None],


### PR DESCRIPTION
This is work in progress for adding Verilog-to-Routing.

- [x] Should the image name be `vtr` or `vpr`?
- [x] ~It seems that `PREFIX` is not honored in the build scripts.~ Fixed by using cmake.
- [ ] Are there any runtime dependencies apart from libgtk-3-bin?

/cc @mithro 