### PR TITLE
Adds aarch64 support for conda container

### DIFF
--- a/debian-bullseye/conda.dockerfile
+++ b/debian-bullseye/conda.dockerfile
@@ -32,7 +32,8 @@ RUN apt-get update -qq \
 
 ENV PREFIX=/usr/local
 
-RUN curl -fsSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > conda_installer.sh \
+RUN arch=$(arch | sed s/arm64/aarch64/ | sed s/amd64/x86_64/) && \
+ curl -fsSL "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-${arch}.sh" > conda_installer.sh \
  && chmod +x conda_installer.sh \
  && ./conda_installer.sh -u -b -p "$PREFIX" \
  && rm conda_installer.sh \


### PR DESCRIPTION
this commit allows for automatic detection of host arch and downloads the according conda install script.

I tested it by building the base image for arm64v8:
```
# build the base image for aarch64/arm64/arm64v8
pyHDLC build -a arm64v8 base --registry local.io
# build conda image with modified dockerfile
pyHDLC build -a arm64v8 conda -i local.io/arm64v8/debian/bullseye/base
```

I'll check what's needed for other package too.