### PR TITLE
Add click python lib to formal:min image

### DIFF
--- a/debian-bullseye/formal.dockerfile
+++ b/debian-bullseye/formal.dockerfile
@@ -34,8 +34,10 @@ COPY --from=pkg-symbiyosys /symbiyosys /
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
     python3 \
+    python3-pip \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && python3 -m pip install click --progress-bar off
 
 #---
 


### PR DESCRIPTION
Fixes #63
 
`formal:min` is used as base for the other `formal:*` images, so I assume that all of them should now include the click library.

As I'm a bit overwhelmed how to use the tools under `utils/` I've checked the build of the `formal:min` by using GHA. It seems to build successfully, but I haven't test yet if `sby` can be run successfully.