### PR TITLE
Add libzstd-dev to NVC dependencies

### DIFF
--- a/debian-bullseye/nvc/HDLC
+++ b/debian-bullseye/nvc/HDLC
@@ -26,11 +26,14 @@ makedepends=(
   autoconf
   check
   flex
+  bison
   libdw-dev
   libffi-dev
   llvm-dev
   pkg-config
   zlib1g-dev
+  libzstd-dev
+  tcl-dev
 )
 
 build() {
@@ -49,4 +52,6 @@ depends=(
   libdw1
   libllvm11
   make
+  libzstd1
+  libtcl8.6
 )

--- a/debian-bullseye/nvc/HDLC
+++ b/debian-bullseye/nvc/HDLC
@@ -2,6 +2,7 @@
 
 # Authors:
 #   Unai Martinez-Corral
+#   Nick Gasson
 #
 # Copyright 2018-2023 Unai Martinez-Corral <unai.martinezcorral@ehu.eus>
 #


### PR DESCRIPTION
The master branch will soon require `libzstd-dev` to build. Also added `bison` and `tcl-dev` which are optional dependencies at the moment but might become required at some point.