### PR TITLE
Update buildfiles with missing build dependencies.

### DIFF
--- a/debian-bullseye/cvc/HDLC
+++ b/debian-bullseye/cvc/HDLC
@@ -34,6 +34,8 @@ makedepends=(
   python3-pyparsing
   python3-toml
   python3-venv
+  python3-pip
+  pkg-config
   openjdk-11-jre-headless
 )
 

--- a/debian-bullseye/ghdl-yosys-plugin.dockerfile
+++ b/debian-bullseye/ghdl-yosys-plugin.dockerfile
@@ -28,6 +28,8 @@ FROM $REGISTRY/yosys AS base
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
     libgnat-9 \
+    g++ \
+    make \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists
 

--- a/debian-bullseye/pono/HDLC
+++ b/debian-bullseye/pono/HDLC
@@ -36,10 +36,16 @@ makedepends=(
   m4
   patch
   python3-toml
+  python3-pip
+  pkg-config
   openjdk-11-jre-headless
 )
 
 build() {
+  pip3 install meson
+  pip3 install ninja
+  pip3 install tomli
+  pip3 install pyparsing
   git clone https://github.com/upscale-project/pono.git /tmp/pono
   cd /tmp/pono
   git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g' > /tmp/hdlc.pono.version

--- a/debian-bullseye/yosys/HDLC
+++ b/debian-bullseye/yosys/HDLC
@@ -26,6 +26,7 @@ makedepends=(
   flex
   gawk
   gcc
+  build-essential
   pkg-config
   zlib1g-dev
   clang
@@ -38,7 +39,7 @@ testdepends=(
 )
 
 build() {
-  git clone https://github.com/YosysHQ/yosys.git /tmp/yosys
+  git clone --recurse-submodules https://github.com/YosysHQ/yosys.git /tmp/yosys
   cd /tmp/yosys
   make -j $(nproc)
   make DESTDIR=/opt/yosys install


### PR DESCRIPTION
These updates should get these images to build, the ghdl image does still not build so one solution is to pull those from docker.io

Will add another PR for that solution.