### PR TITLE
Bookworm fixes to enable making the formal docker

### DIFF
--- a/debian-bookworm/cvc/HDLC
+++ b/debian-bookworm/cvc/HDLC
@@ -34,6 +34,7 @@ makedepends=(
   python3-pyparsing
   python3-toml
   python3-venv
+  python3-pip
   openjdk-17-jre-headless
 )
 

--- a/debian-bookworm/formal.dockerfile
+++ b/debian-bookworm/formal.dockerfile
@@ -69,16 +69,41 @@ RUN apt-get update -qq \
 
 #---
 
-# WORKAROUND: this is required because 'COPY --from' does not support ARGs
-# FROM $REGISTRY/pkg/superprove AS pkg-superprove
+# WORKAROUND: this is required because 'COPY --from' does not support ARGs# Create a francendebian with python2.7 from debian bulseye
+RUN curl -O http://ftp.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb
+RUN curl -O http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb
+RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-8+deb11u1_amd64.deb
+RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.18-8+deb11u1_amd64.deb
+RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-8+deb11u1_amd64.deb
+RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7_2.7.18-8+deb11u1_amd64.deb
+# RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-dev_2.7.18-8+deb11u1_amd64.deb
+# RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-dev_2.7.18-8+deb11u1_amd64.deb
+# RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7_2.7.18-8+deb11u1_amd64.deb
 
-# FROM latest
+RUN apt-get update -qq \
+&& apt-get -y install mime-support 
 
-# COPY --from=pkg-superprove /superprove /
+RUN dpkg -i libffi7_3.3-6_amd64.deb 
+RUN dpkg -i libssl1.1_1.1.1w-0+deb11u1_amd64.deb 
+RUN dpkg -i libpython2.7-minimal_2.7.18-8+deb11u1_amd64.deb 
+RUN dpkg -i python2.7-minimal_2.7.18-8+deb11u1_amd64.deb 
+RUN dpkg -i libpython2.7-stdlib_2.7.18-8+deb11u1_amd64.deb 
+RUN dpkg -i python2.7_2.7.18-8+deb11u1_amd64.deb 
+# RUN dpkg -i libpython2.7_2.7.18-8+deb11u1_amd64.deb
+# RUN dpkg -i libpython2.7-dev_2.7.18-8+deb11u1_amd64.deb 
+# RUN dpkg -i python2.7-dev_2.7.18-8+deb11u1_amd64.deb 
+# End francendebian installs
 
-# RUN apt-get update -qq \
+
+FROM $REGISTRY/pkg/superprove AS pkg-superprove
+
+FROM latest
+
+COPY --from=pkg-superprove /superprove /
+
+RUN apt-get update -qq \
 #  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
    #  python \
    #  libpython2.7 \
-#  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
-#  && rm -rf /var/lib/apt/lists/*
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && rm -rf /var/lib/apt/lists/*

--- a/debian-bookworm/formal.dockerfile
+++ b/debian-bookworm/formal.dockerfile
@@ -1,0 +1,84 @@
+# Authors:
+#   Unai Martinez-Corral
+#     <umartinezcorral@antmicro.com>
+#     <unai.martinezcorral@ehu.eus>
+#   Torsten Meissner
+#   Sverre Hamre
+#
+# Copyright Unai Martinez-Corral
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# ARG REGISTRY='gcr.io/hdl-containers/debian/bookworm'
+ARG REGISTRY='localhost/bookworm'
+
+#---
+
+# WORKAROUND: this is required because 'COPY --from' does not support ARGs
+FROM $REGISTRY/pkg/z3 AS pkg-z3
+FROM $REGISTRY/pkg/sby AS pkg-sby
+
+# FROM $REGISTRY/ghdl/yosys AS min
+FROM $REGISTRY/pkg/ghdl-yosys AS min
+
+COPY --from=pkg-z3 /z3 /
+COPY --from=pkg-sby /sby /
+
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    python3 \
+    python3-pip \
+    python3-click \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+&& rm -rf /var/lib/apt/lists/* 
+# \
+#  && python3 -m pip install click --progress-bar off
+
+#---
+
+# WORKAROUND: this is required because 'COPY --from' does not support ARGs
+FROM $REGISTRY/pkg/yices2 AS pkg-yices2
+FROM $REGISTRY/pkg/boolector AS pkg-boolector
+FROM $REGISTRY/pkg/cvc AS pkg-cvc
+FROM $REGISTRY/pkg/pono AS pkg-pono
+
+FROM min AS latest
+
+COPY --from=pkg-yices2 /yices2 /
+COPY --from=pkg-boolector /boolector /
+COPY --from=pkg-cvc /cvc /
+COPY --from=pkg-pono /pono /
+
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+    libgmpxx4ldbl \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && rm -rf /var/lib/apt/lists/*
+
+#---
+
+# WORKAROUND: this is required because 'COPY --from' does not support ARGs
+# FROM $REGISTRY/pkg/superprove AS pkg-superprove
+
+# FROM latest
+
+# COPY --from=pkg-superprove /superprove /
+
+# RUN apt-get update -qq \
+#  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+   #  python \
+   #  libpython2.7 \
+#  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+#  && rm -rf /var/lib/apt/lists/*

--- a/debian-bookworm/ghdl-yosys-plugin.dockerfile
+++ b/debian-bookworm/ghdl-yosys-plugin.dockerfile
@@ -19,15 +19,18 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG REGISTRY='gcr.io/hdl-containers/debian/bookworm'
+# ARG REGISTRY='gcr.io/hdl-containers/debian/bookworm'
+ARG REGISTRY='localhost/bookworm'
 
 #---
 
-FROM $REGISTRY/yosys AS base
+FROM $REGISTRY/pkg/yosys AS base
 
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
     libgnat-12 \
+    gcc \
+    g++ \
  && apt-get autoclean && apt-get clean && apt-get -y autoremove \
  && rm -rf /var/lib/apt/lists
 

--- a/debian-bookworm/ghdl.dockerfile
+++ b/debian-bookworm/ghdl.dockerfile
@@ -23,7 +23,7 @@ ARG REGISTRY='gcr.io/hdl-containers/debian/bookworm'
 
 #---
 
-FROM ghdl/pkg:bookworm-mcode AS build-mcode
+FROM docker.io/ghdl/pkg:bookworm-mcode AS build-mcode
 
 # TODO Build GHDL on $REGISTRY/build/build instead of picking ghdl/pkg:bookworm-mcode
 
@@ -35,7 +35,7 @@ COPY --from=build-mcode / /ghdl/usr/local/
 
 #---
 
-FROM ghdl/pkg:bookworm-llvm-14 AS build-llvm
+FROM docker.io/ghdl/pkg:bookworm-llvm-14 AS build-llvm
 
 # TODO Build GHDL on $REGISTRY/build/build instead of picking ghdl/pkg:bookworm-llvm-14
 
@@ -62,10 +62,12 @@ FROM base AS mcode
 COPY --from=build-mcode / /usr/local/
 
 #--
-
+   
 FROM base AS llvm
-
+   
 COPY --from=build-llvm / /usr/local/
+COPY --from=build-llvm / /ghdl/usr/local/
+COPY --from=build-mcode / /ghdl/usr/local/
 
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \

--- a/debian-bookworm/pono/Dockerfile
+++ b/debian-bookworm/pono/Dockerfile
@@ -1,0 +1,48 @@
+# Authors:
+#   Unai Martinez-Corral
+#     <umartinezcorral@antmicro.com>
+#     <unai.martinezcorral@ehu.eus>
+#   Torsten Meissner
+#   Sverre Hamre
+#
+# Copyright Unai Martinez-Corral
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ARG REGISTRY='gcr.io/hdl-containers/debian/bookworm'
+
+#---
+
+FROM $REGISTRY/build/build AS build
+
+RUN --mount=type=bind,target=/tmp/ctx . /tmp/ctx/HDLC \
+ && mkdir -p /usr/share/man/man1/ \
+ && apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install ${makedepends[@]} \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && update-ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=bind,target=/tmp/ctx . /tmp/ctx/HDLC && build
+
+#---
+
+FROM scratch AS version
+COPY --from=build /tmp/hdlc.pono.version /
+
+#---
+
+FROM scratch
+COPY --from=build /opt/pono /pono

--- a/debian-bookworm/pono/HDLC
+++ b/debian-bookworm/pono/HDLC
@@ -1,0 +1,53 @@
+# HDLC pono
+
+# Authors:
+#   Unai Martinez-Corral
+#     <umartinezcorral@antmicro.com>
+#     <unai.martinezcorral@ehu.eus>
+#   Torsten Meissner
+#   Sverre Hamre
+#
+# Copyright Unai Martinez-Corral
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+makedepends=(
+  bison
+  cmake
+  flex
+  libbison-dev
+  libgmp-dev
+  python3-pyparsing
+  pkg-config
+  meson
+)
+
+
+build() {
+  git clone https://github.com/upscale-project/pono.git /tmp/pono
+  cd /tmp/pono
+  git describe --long --tags | sed 's/\([^-]*-g\)/r\1/;s/-/./g;s/^v//g' > /tmp/hdlc.pono.version
+  ./contrib/setup-smt-switch.sh
+  ./contrib/setup-btor2tools.sh
+  ./configure.sh
+  PREFIX=/usr/local
+  make -C build -j$(nproc) PREFIX="$PREFIX"
+  DESTDIR=/opt/pono
+  mkdir -p "${DESTDIR}${PREFIX}"/bin "${DESTDIR}${PREFIX}"/lib
+  cp build/pono "${DESTDIR}${PREFIX}"/bin/
+  cp build/libpono.so "${DESTDIR}${PREFIX}"/lib/
+}

--- a/debian-bookworm/superprove/Dockerfile
+++ b/debian-bookworm/superprove/Dockerfile
@@ -1,0 +1,75 @@
+# Authors:
+#   Unai Martinez-Corral
+#     <umartinezcorral@antmicro.com>
+#     <unai.martinezcorral@ehu.eus>
+#   Torsten Meissner
+#   Sverre Hamre
+#
+# Copyright Unai Martinez-Corral
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ARG REGISTRY='gcr.io/hdl-containers/debian/bookworm'
+
+#---
+
+FROM $REGISTRY/build/build AS build
+
+# Create a francendebian with python2.7 from debian bulseye
+RUN curl -O http://ftp.debian.org/debian/pool/main/libf/libffi/libffi7_3.3-6_amd64.deb
+RUN curl -O http://ftp.debian.org/debian/pool/main/o/openssl/libssl1.1_1.1.1w-0+deb11u1_amd64.deb
+RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-minimal_2.7.18-8+deb11u1_amd64.deb
+RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-minimal_2.7.18-8+deb11u1_amd64.deb
+RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-stdlib_2.7.18-8+deb11u1_amd64.deb
+RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7_2.7.18-8+deb11u1_amd64.deb
+RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7-dev_2.7.18-8+deb11u1_amd64.deb
+RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/python2.7-dev_2.7.18-8+deb11u1_amd64.deb
+RUN curl -O http://ftp.debian.org/debian/pool/main/p/python2.7/libpython2.7_2.7.18-8+deb11u1_amd64.deb
+
+RUN apt-get update -qq \
+&& apt-get -y install mime-support libexpat1-dev
+
+RUN dpkg -i libffi7_3.3-6_amd64.deb 
+RUN dpkg -i libssl1.1_1.1.1w-0+deb11u1_amd64.deb 
+RUN dpkg -i libpython2.7-minimal_2.7.18-8+deb11u1_amd64.deb 
+RUN dpkg -i python2.7-minimal_2.7.18-8+deb11u1_amd64.deb 
+RUN dpkg -i libpython2.7-stdlib_2.7.18-8+deb11u1_amd64.deb 
+RUN dpkg -i python2.7_2.7.18-8+deb11u1_amd64.deb 
+RUN dpkg -i libpython2.7_2.7.18-8+deb11u1_amd64.deb
+RUN dpkg -i libpython2.7-dev_2.7.18-8+deb11u1_amd64.deb 
+RUN dpkg -i python2.7-dev_2.7.18-8+deb11u1_amd64.deb 
+# End francendebian installs
+
+
+RUN --mount=type=bind,target=/tmp/ctx . /tmp/ctx/HDLC \
+ && apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends ${makedepends[@]} \
+ && apt-get autoclean && apt-get clean && apt-get -y autoremove \
+ && update-ca-certificates \
+ && rm -rf /var/lib/apt/lists/* 
+ #\
+ #&& prepare
+
+RUN --mount=type=bind,target=/tmp/ctx . /tmp/ctx/HDLC && build
+
+#---
+
+FROM scratch AS version
+COPY --from=build /tmp/hdlc.superprove.version /
+
+#---
+
+FROM scratch
+COPY --from=build /opt/superprove /superprove

--- a/debian-bookworm/superprove/HDLC
+++ b/debian-bookworm/superprove/HDLC
@@ -1,0 +1,60 @@
+# HDLC superprove
+
+# Authors:
+#   Unai Martinez-Corral
+#     <umartinezcorral@antmicro.com>
+#     <unai.martinezcorral@ehu.eus>
+#   Torsten Meissner
+#   Sverre Hamre
+#
+# Copyright Unai Martinez-Corral
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+CTX=/tmp/ctx
+
+makedepends=(
+  binutils
+  cmake
+  ninja-build
+  patch
+  # python-setuptools
+  # python-wheel-common
+  # python-dev-is-python2
+  zlib1g-dev
+)
+
+prepare() {
+  curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python
+}
+
+build() {
+  git clone --recursive https://github.com/sterin/super-prove-build /tmp/superprove
+  cd /tmp/superprove/super_prove
+  git describe --always | sed 's/\(.*\)/g\1/' > /tmp/hdlc.superprove.version
+  cd ..
+  patch -p1 < ${CTX}/rm-system.patch
+  mkdir build && cd build
+  PREFIX=/usr/local
+  cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$PREFIX" -G Ninja ..
+  ninja
+  ninja package
+  DESTDIR=/opt/superprove
+  mkdir -p "${DESTDIR}${PREFIX}"
+  tar -C "${DESTDIR}${PREFIX}" -xzf super_prove*.tar.gz --strip 1
+  cp ${CTX}/suprove "${DESTDIR}${PREFIX}"/bin/suprove
+}

--- a/debian-bookworm/superprove/rm-system.patch
+++ b/debian-bookworm/superprove/rm-system.patch
@@ -1,0 +1,31 @@
+# Authors:
+#   Unai Martinez-Corral
+#     <unai.martinezcorral@ehu.eus>
+#   Torsten Meissner
+#   Sverre Hamre
+#
+# Copyright Unai Martinez-Corral
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+diff --git a/cmake/install_rules.cmake b/cmake/install_rules.cmake
+index fed7af4..08e0cf5 100644
+--- a/cmake/install_rules.cmake
++++ b/cmake/install_rules.cmake
+@@ -62 +61,0 @@ function(install_python_requirements file)
+-                --system
+--
+2.33.0
+

--- a/debian-bookworm/superprove/suprove
+++ b/debian-bookworm/superprove/suprove
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Authors:
+#   Unai Martinez-Corral
+#     <umartinezcorral@antmicro.com>
+#     <unai.martinezcorral@ehu.eus>
+#   Torsten Meissner
+#   Sverre Hamre
+#
+# Copyright Unai Martinez-Corral
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+tool=super_prove
+
+if [ "$1" != "${1#+}" ]; then
+  tool="${1#+}"
+  shift
+fi
+
+exec ${tool}.sh "$@"

--- a/debian-bookworm/yosys/HDLC
+++ b/debian-bookworm/yosys/HDLC
@@ -56,4 +56,5 @@ depends=(
   tcl-dev
   graphviz
   xdot
+  gtkwave 
 )

--- a/debian-bookworm/yosys/HDLC
+++ b/debian-bookworm/yosys/HDLC
@@ -26,6 +26,7 @@ makedepends=(
   flex
   gawk
   gcc
+  g++
   pkg-config
   zlib1g-dev
   clang
@@ -38,7 +39,7 @@ testdepends=(
 )
 
 build() {
-  git clone https://github.com/YosysHQ/yosys.git /tmp/yosys
+  git clone --recurse-submodules https://github.com/YosysHQ/yosys.git /tmp/yosys
   cd /tmp/yosys
   make -j $(nproc)
   make DESTDIR=/opt/yosys install


### PR DESCRIPTION
Added images needed to be able to build the formal docker with bookworm.
This is without superprove as that is more difficult to get working with bookworm where there is no python2.7 support.